### PR TITLE
Add six module as require package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
     include_package_data=True,
     license='BSD',
     install_requires=(
+        'six',
     ),
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
The six module is imported for example at `values.py`

When I try to run my project, it throws:

> ImportError: No module named six
