### PR TITLE
Compatibility patch for python 3.3+

### DIFF
--- a/dbsettings/group.py
+++ b/dbsettings/group.py
@@ -13,6 +13,7 @@ class GroupBase(type):
             return
         attrs.pop('__module__', None)
         attrs.pop('__doc__', None)
+        attrs.pop('__qualname__', None)
         for attribute_name, attr in attrs.items():
             if not isinstance(attr, Value):
                 raise TypeError('The type of %s (%s) is not a valid Value.' %


### PR DESCRIPTION
`__qualname__` attr was introduced in python 3.3:
https://docs.python.org/3.3/library/stdtypes.html#class.__qualname__
and it has broken type checks. This small patch fixes it.
