### PR TITLE
Use six from django.utils.six and no six package from default python

### DIFF
--- a/dbsettings/group.py
+++ b/dbsettings/group.py
@@ -1,5 +1,5 @@
 import sys
-import six
+from django.utils import six
 
 from dbsettings.values import Value
 from dbsettings.loading import register_setting, unregister_setting

--- a/dbsettings/tests/tests.py
+++ b/dbsettings/tests/tests.py
@@ -1,4 +1,4 @@
-import six
+from django.utils import six
 import datetime
 
 import django

--- a/dbsettings/values.py
+++ b/dbsettings/values.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
-import six
+from django.utils import six
 
 import datetime
 from decimal import Decimal

--- a/dbsettings/views.py
+++ b/dbsettings/views.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
-import six
+from django.utils import six
 
 from django.http import HttpResponseRedirect
 from django.shortcuts import render_to_response


### PR DESCRIPTION
The main change is about use six from django.utils.six package to avoi version conflicts with six package from default python package. Depending on six version the dbsettings broke with "AttributeError: 'module' object has no attribute 'add_metaclass'"
Another changes is trivial conversion from dos to unix format.

Backtrace:
<pre>
Traceback (most recent call last):
  File "./manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/iptv/var/www/sites/site_iptv/django/core/management/__init__.py", line 399, in execute_from_command_line
    utility.execute()
  File "/iptv/var/www/sites/site_iptv/django/core/management/__init__.py", line 392, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/iptv/var/www/sites/site_iptv/django/core/management/base.py", line 242, in run_from_argv
    self.execute(*args, **options.__dict__)
  File "/iptv/var/www/sites/site_iptv/django/core/management/base.py", line 280, in execute
    translation.activate('en-us')
  File "/iptv/var/www/sites/site_iptv/django/utils/translation/__init__.py", line 130, in activate
    return _trans.activate(language)
  File "/iptv/var/www/sites/site_iptv/django/utils/translation/trans_real.py", line 188, in activate
    _active.value = translation(language)
  File "/iptv/var/www/sites/site_iptv/django/utils/translation/trans_real.py", line 177, in translation
    default_translation = _fetch(settings.LANGUAGE_CODE)
  File "/iptv/var/www/sites/site_iptv/django/utils/translation/trans_real.py", line 159, in _fetch
    app = import_module(appname)
  File "/iptv/var/www/sites/site_iptv/django/utils/importlib.py", line 40, in import_module
    __import__(name)
  File "/iptv/var/www/sites/site_iptv/dbsettings/__init__.py", line 2, in <module>
    from dbsettings.group import *  # NOQA
  File "/iptv/var/www/sites/site_iptv/dbsettings/group.py", line 37, in <module>
    @six.add_metaclass(GroupBase)
AttributeError: 'module' object has no attribute 'add_metaclass'
</pre>