### PR TITLE
Force zip_safe=False to avoid auto-detection

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,4 +39,5 @@ setup(
         'Programming Language :: Python',
         'Topic :: Utilities'
     ],
+    zip_safe=False,
 )


### PR DESCRIPTION
Some versions of setuptools seem to auto-detect the dbsettings package as being "zip-safe" and do not unzip the egg (I've seen differing behavior -- one system unzips, another one does not). 
```
Getting distribution for 'django-dbsettings==0.8.2'.
warning: no previously-included files found matching 'runtests.py'
zip_safe flag not set; analyzing archive contents...
Got django-dbsettings 0.8.2.
```

This causes a problem for Django's migration loading, since it uses `os.listdir` to scan the migrations directory (the `os.listdir` fails for the zipped egg format):
```
  File "workspace/eggs/Django-1.8.4-py2.7.egg/django/db/migrations/loader.py", line 93, in load_disk
    for name in os.listdir(directory):
OSError: [Errno 20] Not a directory: 'workspace/eggs/django_dbsettings-0.8.2-py2.7.egg/dbsettings/migrations'
```

I understand this is change may have little value to many people, but it seems to be a low risk change to explicitly state that the package should not be zipped.

Thanks!