### PR TITLE
Remove heading "Application settings" | Add missing trans tag for "Save" (issue #30

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,3 +11,4 @@ Alexander Danilenko
 Igor Tokarev
 Helber Maciel Guerra
 Mlier
+Jonathan Weth (@hansegucker)

--- a/dbsettings/templates/dbsettings/site_settings.html
+++ b/dbsettings/templates/dbsettings/site_settings.html
@@ -28,16 +28,18 @@
             <caption>{% filter capfirst %}{{ module.grouper }}{% endfilter %}</caption>
             {% regroup module.list by class_name as classes %}
             {% for class in classes %}
-                <tr class="alt">
-                    <th>{% filter capfirst %}{% if class.grouper %}{{ class.grouper }}{% else %}{% trans "Application settings" %}{% endif %}{% endfilter %}</th>
-                    <th>&nbsp;</th>
-                </tr>
+                {% if class.grouper %}
+                    <tr class="alt">
+                        <th>{% filter capfirst %}{% if class.grouper %}{{ class.grouper }}{% endif %}{% endfilter %}</th>
+                        <th>&nbsp;</th>
+                    </tr>
+                {% endif %}
                 {% include "dbsettings/values.html" %}
             {% endfor %}
             </table>
         </div>
     {% endfor %}
-{% csrf_token %}<input type="submit" value="Save" class="default" />
+{% csrf_token %}<input type="submit" value="{% trans "Save" %}" class="default" />
 </form>
 {% else %}
     <p>{% trans "You don't have permission to edit values." %}</p>


### PR DESCRIPTION
I removed the extra heading "Application settings" because everyone clearly sees that the settings under the title of an application are settings which are assigned to this application. See issue #30

Extra change: Add {% trans %} for save button