### PR TITLE
Fixed render method of ImageValue for Django 2.1 onwards

### DIFF
--- a/dbsettings/values.py
+++ b/dbsettings/values.py
@@ -279,7 +279,7 @@ class ImageValue(Value):
         class widget(forms.FileInput):
             "Widget with preview"
 
-            def render(self, name, value, attrs=None):
+            def render(self, name, value, attrs=None, renderer=None):
                 output = []
 
                 try:
@@ -294,7 +294,7 @@ class ImageValue(Value):
                 except IOError:
                     pass
 
-                output.append(forms.FileInput.render(self, name, value, attrs))
+                output.append(forms.FileInput.render(self, name, value, attrs, renderer))
                 return mark_safe(''.join(output))
 
     def to_python(self, value):


### PR DESCRIPTION
Fixed an issue where the rendering of an ImageValue field failed in Django 2.1 onwards with the error `render() got an unexpected keyword argument 'renderer'`.