### PR TITLE
Adding get_field_display method for Value with choices

### DIFF
--- a/dbsettings/group.py
+++ b/dbsettings/group.py
@@ -4,6 +4,9 @@ from dbsettings.values import Value
 from dbsettings.loading import register_setting, unregister_setting
 from dbsettings.management import mk_permissions
 
+from django.utils.encoding import force_str
+from django.utils.hashable import make_hashable
+
 __all__ = ['Group']
 
 
@@ -116,3 +119,9 @@ class Group(object, metaclass=GroupBase):
 
     def values(self):
         return [v for (_, v) in self]
+
+    def _get_FIELD_display(self, field):
+        value = getattr(self, field.attribute_name)
+        choices_dict = dict(make_hashable(field.choices))
+        # force_str() to coerce lazy strings.
+        return force_str(choices_dict.get(make_hashable(value), value), strings_only=True)

--- a/dbsettings/values.py
+++ b/dbsettings/values.py
@@ -4,6 +4,7 @@ import datetime
 from decimal import Decimal
 from hashlib import md5
 from os.path import join as pjoin
+from functools import partialmethod
 import time
 import os
 
@@ -62,6 +63,15 @@ class Value(object):
         self.description = self.description or attribute_name.replace('_', ' ')
 
         setattr(cls, self.attribute_name, self)
+
+        if self.choices is not None:
+            # Allows for adding get_FIELD_display() to fields with choices.
+            if 'get_%s_display' % attribute_name not in cls.__dict__:
+                setattr(
+                    cls,
+                    'get_%s_display' % attribute_name,
+                    partialmethod(cls._get_FIELD_display, field=self),
+                )
 
     @property
     def app(self):

--- a/dbsettings/values.py
+++ b/dbsettings/values.py
@@ -66,10 +66,11 @@ class Value(object):
 
         if self.choices is not None:
             # Allows for adding get_FIELD_display() to fields with choices.
-            if 'get_%s_display' % attribute_name not in cls.__dict__:
+            display_attribute = 'get_%s_display' % attribute_name
+            if display_attribute not in cls.__dict__:
                 setattr(
                     cls,
-                    'get_%s_display' % attribute_name,
+                    display_attribute,
                     partialmethod(cls._get_FIELD_display, field=self),
                 )
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -13,7 +13,7 @@ class TestSettings(dbsettings.Group):
     date = dbsettings.DateValue()
     time = dbsettings.TimeValue()
     datetime = dbsettings.DateTimeValue()
-    string_choices = dbsettings.StringValue(choices=(("String1", "String 1"), ("String2", "String 2")))
+    string_choices = dbsettings.StringValue(choices=(("String1", "First String Choice"), ("String2", "Second String Choice")))
 
 
 class Defaults(models.Model):
@@ -27,7 +27,7 @@ class Defaults(models.Model):
         date = dbsettings.DateValue(default=datetime.date(2012, 3, 14))
         time = dbsettings.TimeValue(default=datetime.time(12, 3, 14))
         datetime = dbsettings.DateTimeValue(default=datetime.datetime(2012, 3, 14, 12, 3, 14))
-        string_choices = dbsettings.StringValue(choices=(("String1", "String 1"), ("String2", "String 2")), default="String2")
+        string_choices = dbsettings.StringValue(choices=(("String1", "First String Choice"), ("String2", "Second String Choice")), default="String2")
     settings = settings()
 
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -13,6 +13,7 @@ class TestSettings(dbsettings.Group):
     date = dbsettings.DateValue()
     time = dbsettings.TimeValue()
     datetime = dbsettings.DateTimeValue()
+    string_choices = dbsettings.StringValue(choices=(("String1", "String 1"), ("String2", "String 2")))
 
 
 class Defaults(models.Model):
@@ -26,6 +27,7 @@ class Defaults(models.Model):
         date = dbsettings.DateValue(default=datetime.date(2012, 3, 14))
         time = dbsettings.TimeValue(default=datetime.time(12, 3, 14))
         datetime = dbsettings.DateTimeValue(default=datetime.datetime(2012, 3, 14, 12, 3, 14))
+        string_choices = dbsettings.StringValue(choices=(("String1", "String 1"), ("String2", "String 2")), default="String2")
     settings = settings()
 
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -88,7 +88,7 @@ class SettingsTestCase(test.TestCase):
         self.assertEqual(Populated.settings.time, datetime.time(16, 19, 17))
         self.assertEqual(Populated.settings.datetime, datetime.datetime(2012, 6, 28, 16, 19, 17))
         self.assertEqual(Populated.settings.string_choices, "String1")
-        self.assertEqual(Populated.settings.get_string_choices_display(), "String 1")
+        self.assertEqual(Populated.settings.get_string_choices_display(), "First String Choice")
 
         # Module settings are kept separate from model settings
         self.assertEqual(module_settings.boolean, False)
@@ -111,7 +111,7 @@ class SettingsTestCase(test.TestCase):
         self.assertEqual(Combined.settings.time, datetime.time(14, 17, 15))
         self.assertEqual(Combined.settings.datetime, datetime.datetime(2010, 4, 26, 14, 17, 15))
         self.assertEqual(Combined.settings.string_choices, "String1")
-        self.assertEqual(Combined.settings.get_string_choices_display(), "String 1")
+        self.assertEqual(Combined.settings.get_string_choices_display(), "First String Choice")
 
 
         # Settings not in the database use empty defaults
@@ -132,7 +132,7 @@ class SettingsTestCase(test.TestCase):
         self.assertEqual(Defaults.settings.time, datetime.time(12, 3, 14))
         self.assertEqual(Defaults.settings.datetime, datetime.datetime(2012, 3, 14, 12, 3, 14))
         self.assertEqual(Defaults.settings.string_choices, "String2")
-        self.assertEqual(Defaults.settings.get_string_choices_display(), "String 2")
+        self.assertEqual(Defaults.settings.get_string_choices_display(), "Second String Choice")
 
         # Settings should be retrieved in the order of definition
         self.assertEqual(Populated.settings.keys(),

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -52,6 +52,7 @@ class SettingsTestCase(test.TestCase):
         loading.set_setting_value(MODULE_NAME, 'Populated', 'date', '2012-06-28')
         loading.set_setting_value(MODULE_NAME, 'Populated', 'time', '16:19:17')
         loading.set_setting_value(MODULE_NAME, 'Populated', 'datetime', '2012-06-28 16:19:17')
+        loading.set_setting_value(MODULE_NAME, 'Populated', 'string_choices', 'String1')
         loading.set_setting_value(MODULE_NAME, '', 'boolean', False)
         loading.set_setting_value(MODULE_NAME, '', 'integer', 14)
         loading.set_setting_value(MODULE_NAME, '', 'string', 'Module')
@@ -71,6 +72,7 @@ class SettingsTestCase(test.TestCase):
         loading.set_setting_value(MODULE_NAME, 'Combined', 'date', '2010-04-26')
         loading.set_setting_value(MODULE_NAME, 'Combined', 'time', '14:17:15')
         loading.set_setting_value(MODULE_NAME, 'Combined', 'datetime', '2010-04-26 14:17:15')
+        loading.set_setting_value(MODULE_NAME, 'Combined', 'string_choices', 'String1')
         loading.set_setting_value(MODULE_NAME, 'Combined', 'enabled', True)
 
     def test_settings(self):
@@ -85,6 +87,8 @@ class SettingsTestCase(test.TestCase):
         self.assertEqual(Populated.settings.date, datetime.date(2012, 6, 28))
         self.assertEqual(Populated.settings.time, datetime.time(16, 19, 17))
         self.assertEqual(Populated.settings.datetime, datetime.datetime(2012, 6, 28, 16, 19, 17))
+        self.assertEqual(Populated.settings.string_choices, "String1")
+        self.assertEqual(Populated.settings.get_string_choices_display(), "String 1")
 
         # Module settings are kept separate from model settings
         self.assertEqual(module_settings.boolean, False)
@@ -106,6 +110,9 @@ class SettingsTestCase(test.TestCase):
         self.assertEqual(Combined.settings.date, datetime.date(2010, 4, 26))
         self.assertEqual(Combined.settings.time, datetime.time(14, 17, 15))
         self.assertEqual(Combined.settings.datetime, datetime.datetime(2010, 4, 26, 14, 17, 15))
+        self.assertEqual(Combined.settings.string_choices, "String1")
+        self.assertEqual(Combined.settings.get_string_choices_display(), "String 1")
+
 
         # Settings not in the database use empty defaults
         self.assertEqual(Unpopulated.settings.boolean, False)
@@ -124,14 +131,16 @@ class SettingsTestCase(test.TestCase):
         self.assertEqual(Defaults.settings.date, datetime.date(2012, 3, 14))
         self.assertEqual(Defaults.settings.time, datetime.time(12, 3, 14))
         self.assertEqual(Defaults.settings.datetime, datetime.datetime(2012, 3, 14, 12, 3, 14))
+        self.assertEqual(Defaults.settings.string_choices, "String2")
+        self.assertEqual(Defaults.settings.get_string_choices_display(), "String 2")
 
         # Settings should be retrieved in the order of definition
         self.assertEqual(Populated.settings.keys(),
                          ['boolean', 'integer', 'string', 'list_semi_colon',
-                          'list_comma', 'date', 'time', 'datetime'])
+                          'list_comma', 'date', 'time', 'datetime', 'string_choices'])
         self.assertEqual(Combined.settings.keys(),
                          ['boolean', 'integer', 'string', 'list_semi_colon',
-                          'list_comma', 'date', 'time', 'datetime', 'enabled'])
+                          'list_comma', 'date', 'time', 'datetime', 'string_choices', 'enabled'])
 
         # Values should be coerced to the proper Python types
         self.assertTrue(isinstance(Populated.settings.boolean, bool))
@@ -319,6 +328,7 @@ class SettingsTestCase(test.TestCase):
             '%s__Editable__date' % MODULE_NAME: '2012-06-28',
             '%s__Editable__time' % MODULE_NAME: '16:37:45',
             '%s__Editable__datetime' % MODULE_NAME: '2012-06-28 16:37:45',
+            '%s__Editable__string_choices' % MODULE_NAME: 'String1',
         }
         response = self.client.post(site_form, data)
         self.assertRedirects(response, site_form)
@@ -351,15 +361,15 @@ class SettingsTestCase(test.TestCase):
         user.user_permissions.remove(perm)
 
         # Check if module level settings show properly
-        self._test_form_fields(site_form, 8, False)
+        self._test_form_fields(site_form, 9, False)
         # Add perm for whole app
         perm = Permission.objects.get(codename='can_edit__settings')  # module-level settings
         user.user_permissions.add(perm)
-        self._test_form_fields(site_form, 18)
+        self._test_form_fields(site_form, 20)
         # Remove other perms - left only global perm
         perm = Permission.objects.get(codename='can_edit_editable_settings')
         user.user_permissions.remove(perm)
-        self._test_form_fields(site_form, 10)
+        self._test_form_fields(site_form, 11)
 
     def _test_form_fields(self, url, fields_num, present=True, variable_name='form'):
         global_setting = '%s____clash2' % MODULE_NAME  # Some global setting name


### PR DESCRIPTION
This PR purpose is to allow `Value` that have choices for getting the display value. The implementation is similar to Django `Field` get_FIELD_display.

Example (More on tests):
country = dbsettings.StringValue(choices=(("USA", "United States"), ("BR", "Brazil")))

`setting.country` would return USA
`setting.get_country_display()` would return United States


