### PR TITLE
Allow to disable cache on field level

### DIFF
--- a/dbsettings/values.py
+++ b/dbsettings/values.py
@@ -29,12 +29,20 @@ class Value(object):
     creation_counter = 0
     unitialized_value = None
 
-    def __init__(self, description=None, help_text=None, choices=None, required=True, default=None, widget=None):
+    def __init__(self,
+                 description=None,
+                 help_text=None,
+                 choices=None,
+                 required=True,
+                 default=None,
+                 widget=None,
+                 disable_cache=False):
         self.description = description
         self.help_text = help_text
         self.choices = choices or []
         self.required = required
         self.widget = widget
+        self.disable_cache = disable_cache
         if default is None:
             self.default = self.unitialized_value
         else:

--- a/tests/models.py
+++ b/tests/models.py
@@ -14,7 +14,7 @@ class TestSettings(dbsettings.Group):
     time = dbsettings.TimeValue()
     datetime = dbsettings.DateTimeValue()
     string_choices = dbsettings.StringValue(choices=(("String1", "First String Choice"), ("String2", "Second String Choice")))
-
+    no_caching_string = dbsettings.StringValue(disable_cache=True)
 
 class Defaults(models.Model):
     class settings(dbsettings.Group):


### PR DESCRIPTION
This PR is to allow for setting `disable_cache` on a field level.

Reason behind the PR:

We currently have multi-threads, including background workers and main application updating a dbsetting. In our case this dbsetting is used for OAuth tokens. The setting is becoming stale since the main application can update the setting, however the background worker till has the state cached data.

This solves the issue by disabling cache on a field level, so we can disabled for specific field to tell anyone who accesses this setting, it should grab from the Database, and not from django cache.