### PR TITLE
build: bump python to 3.13 and django to 5.2

### DIFF
--- a/dbsettings/group.py
+++ b/dbsettings/group.py
@@ -17,6 +17,8 @@ class GroupBase(type):
         attrs.pop('__module__', None)
         attrs.pop('__doc__', None)
         attrs.pop('__qualname__', None)
+        attrs.pop('__firstlineno__', None)
+        attrs.pop('__static_attributes__', None)
         for attribute_name, attr in attrs.items():
             if not isinstance(attr, Value):
                 raise TypeError('The type of %s (%s) is not a valid Value.' %

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -304,19 +304,19 @@ class SettingsTestCase(test.TestCase):
             '%s__Editable__datetime' % MODULE_NAME: '',
         }
         response = self.client.post(site_form, data)
-        self.assertFormError(response, 'form', '%s__Editable__integer' % MODULE_NAME,
+        self.assertFormError(response.context['form'], '%s__Editable__integer' % MODULE_NAME,
                              'Enter a whole number.')
-        self.assertFormError(response, 'form', '%s__Editable__string' % MODULE_NAME,
+        self.assertFormError(response.context['form'], '%s__Editable__string' % MODULE_NAME,
                              'This field is required.')
-        self.assertFormError(response, 'form', '%s__Editable__list_semi_colon' % MODULE_NAME,
+        self.assertFormError(response.context['form'], '%s__Editable__list_semi_colon' % MODULE_NAME,
                              'This field is required.')
-        self.assertFormError(response, 'form', '%s__Editable__list_comma' % MODULE_NAME,
+        self.assertFormError(response.context['form'], '%s__Editable__list_comma' % MODULE_NAME,
                              'This field is required.')
-        self.assertFormError(response, 'form', '%s__Editable__date' % MODULE_NAME,
+        self.assertFormError(response.context['form'], '%s__Editable__date' % MODULE_NAME,
                              'Enter a valid date.')
-        self.assertFormError(response, 'form', '%s__Editable__time' % MODULE_NAME,
+        self.assertFormError(response.context['form'], '%s__Editable__time' % MODULE_NAME,
                              'Enter a valid time.')
-        self.assertFormError(response, 'form', '%s__Editable__datetime' % MODULE_NAME,
+        self.assertFormError(response.context['form'], '%s__Editable__datetime' % MODULE_NAME,
                              'This field is required.')
 
         # Successful submissions should redirect


### PR DESCRIPTION
[build: bump django to 5.2](https://github.com/zlorf/django-dbsettings/commit/eebdba6abeb4f829e38dcb826341acc795d4e68c) 
- update arguments of assertFormError

[build: bump python to 3.13](https://github.com/zlorf/django-dbsettings/commit/82099cc2bcf13e94e882f099700c1242dc90f55c) 
- pop new attributes `__firstlineno__` and `__static_attributes__`
 when validating GroupBase